### PR TITLE
Perform root digest

### DIFF
--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -15,6 +15,16 @@
                     return false;
                 }
 
+                if (attr.hashkey !== element.attr('hashkey')) {
+                    var unwatch = scope.$watch(function() {
+                        return element.attr('hashkey');
+                    }, function() {
+                        unwatch && unwatch();
+                        link.call(this, scope, element, attr);
+                    });
+                    return true;
+                }
+
                 var container = (attr.viewportWatchContainer && attr.viewportWatchContainer.length > 1) ? attr.viewportWatchContainer : undefined;
 
                 var elementWatcher = scrollMonitor.create(element, scope.$eval(attr.viewportWatch || "0"), container);

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -73,12 +73,14 @@
                 function enableDigest() {
                     toggleWatchers(scope, true);
                 }
-                scope.$applyAsync(function() {
+                function disableDigestingIfOutsideViewport() {
                     if (!elementWatcher.isInViewport) {
                         disableDigest();
                         debouncedViewportUpdate();
                     }
-                });
+                }
+                scope.$applyAsync(disableDigestingIfOutsideViewport);
+
                 elementWatcher.enterViewport(enableDigest);
                 elementWatcher.exitViewport(disableDigest);
                 scope.$on("toggleWatchers", function(event, enable) {

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -9,9 +9,8 @@
                 scrollMonitor.update();
             }, 10);
         }
-        return {
-            restrict: "AE",
-            link: function(scope, element, attr) {
+
+        var link = function(scope, element, attr) {
                 if($parse(attr.viewportWatch)(scope) == false){
                     return false;
                 }
@@ -79,7 +78,11 @@
                     elementWatcher.destroy();
                     debouncedViewportUpdate();
                 });
-            }
+            };
+
+        return {
+            restrict: "AE",
+            link: link
         };
     }
     viewportWatch.$inject = [ "scrollMonitor", "$timeout", "$parse" ];

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -64,10 +64,12 @@
                 function enableDigest() {
                     toggleWatchers(scope, true);
                 }
-                if (!elementWatcher.isInViewport) {
-                    scope.$evalAsync(disableDigest);
-                    debouncedViewportUpdate();
-                }
+                scope.$applyAsync(function() {
+                    if (!elementWatcher.isInViewport) {
+                        disableDigest();
+                        debouncedViewportUpdate();
+                    }
+                });
                 elementWatcher.enterViewport(enableDigest);
                 elementWatcher.exitViewport(disableDigest);
                 scope.$on("toggleWatchers", function(event, enable) {

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -10,15 +10,12 @@
             }, 10);
         }
 
-        function createDebouncing(theThis, func, delay) {
+        function createDebouncingVersion(func, delay) {
             var debounceTimeout;
-            var debounced = function () {
+            return function () {
                 clearTimeout(debounceTimeout);
-                debounceTimeout = setTimeout(function () {
-                    func.call(theThis);
-                }, delay);
+                debounceTimeout = setTimeout(func, delay);
             };
-            return debounced;
         }
 
         var link = function(scope, element, attr) {
@@ -78,7 +75,7 @@
                     scope.$digest();
 
                     if (!$rootScope.debouncingApplyAsync) {
-                        $rootScope.debouncingApplyAsync = createDebouncing($rootScope, function () {
+                        $rootScope.debouncingApplyAsync = createDebouncingVersion(function () {
                             $rootScope.$applyAsync();
                         }, 10);
                     }

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -27,10 +27,10 @@
             }
 
             if (attr.hashkey !== element.attr('hashkey')) {
-                var unwatch = scope.$watch(function() {
+                var unwatchFunction = scope.$watch(function() {
                     return element.attr('hashkey');
                 }, function() {
-                    unwatch && unwatch();
+                    unwatchFunction && unwatchFunction();
                     link.call(this, scope, element, attr);
                 });
                 return true;

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -11,86 +11,86 @@
         }
 
         var link = function(scope, element, attr) {
-                if($parse(attr.viewportWatch)(scope) == false){
-                    return false;
-                }
+            if($parse(attr.viewportWatch)(scope) == false){
+                return false;
+            }
 
-                if (attr.hashkey !== element.attr('hashkey')) {
-                    var unwatch = scope.$watch(function() {
-                        return element.attr('hashkey');
-                    }, function() {
-                        unwatch && unwatch();
-                        link.call(this, scope, element, attr);
-                    });
-                    return true;
-                }
+            if (attr.hashkey !== element.attr('hashkey')) {
+                var unwatch = scope.$watch(function() {
+                    return element.attr('hashkey');
+                }, function() {
+                    unwatch && unwatch();
+                    link.call(this, scope, element, attr);
+                });
+                return true;
+            }
 
-                var container = (attr.viewportWatchContainer && attr.viewportWatchContainer.length > 1) ? attr.viewportWatchContainer : undefined;
+            var container = (attr.viewportWatchContainer && attr.viewportWatchContainer.length > 1) ? attr.viewportWatchContainer : undefined;
 
-                var elementWatcher = scrollMonitor.create(element, scope.$eval(attr.viewportWatch || "0"), container);
+            var elementWatcher = scrollMonitor.create(element, scope.$eval(attr.viewportWatch || "0"), container);
 
-                function watchDuringDisable() {
-                    this.$$watchersBackup = this.$$watchersBackup || [];
-                    this.$$watchers = this.$$watchersBackup;
-                    var unwatch = this.constructor.prototype.$watch.apply(this, arguments);
-                    this.$$watchers = null;
-                    return unwatch;
-                }
-                function toggleWatchers(scope, enable) {
-                    var digest, current, next = scope;
-                    do {
-                        current = next;
-                        if (enable) {
-                            if (current.hasOwnProperty("$$watchersBackup")) {
-                                current.$$watchers = current.$$watchersBackup;
-                                delete current.$$watchersBackup;
-                                delete current.$watch;
-                                digest = !scope.$root.$$phase;
-                            }
+            function watchDuringDisable() {
+                this.$$watchersBackup = this.$$watchersBackup || [];
+                this.$$watchers = this.$$watchersBackup;
+                var unwatch = this.constructor.prototype.$watch.apply(this, arguments);
+                this.$$watchers = null;
+                return unwatch;
+            }
+            function toggleWatchers(scope, enable) {
+                var digest, current, next = scope;
+                do {
+                    current = next;
+                    if (enable) {
+                        if (current.hasOwnProperty("$$watchersBackup")) {
+                            current.$$watchers = current.$$watchersBackup;
+                            delete current.$$watchersBackup;
+                            delete current.$watch;
+                            digest = !scope.$root.$$phase;
+                        }
+                    } else {
+                        if (!current.hasOwnProperty("$$watchersBackup")) {
+                            current.$$watchersBackup = current.$$watchers;
+                            current.$$watchers = null;
+                            current.$watch = watchDuringDisable;
+                        }
+                    }
+                    next = current.$$childHead;
+                    while (!next && current !== scope) {
+                        if (current.$$nextSibling) {
+                            next = current.$$nextSibling;
                         } else {
-                            if (!current.hasOwnProperty("$$watchersBackup")) {
-                                current.$$watchersBackup = current.$$watchers;
-                                current.$$watchers = null;
-                                current.$watch = watchDuringDisable;
-                            }
+                            current = current.$parent;
                         }
-                        next = current.$$childHead;
-                        while (!next && current !== scope) {
-                            if (current.$$nextSibling) {
-                                next = current.$$nextSibling;
-                            } else {
-                                current = current.$parent;
-                            }
-                        }
-                    } while (next);
-                    if (digest) {
-                        scope.$digest();
                     }
+                } while (next);
+                if (digest) {
+                    scope.$digest();
                 }
-                function disableDigest() {
-                    toggleWatchers(scope, false);
-                }
-                function enableDigest() {
-                    toggleWatchers(scope, true);
-                }
-                function disableDigestingIfOutsideViewport() {
-                    if (!elementWatcher.isInViewport) {
-                        disableDigest();
-                        debouncedViewportUpdate();
-                    }
-                }
-                scope.$applyAsync(disableDigestingIfOutsideViewport);
-
-                elementWatcher.enterViewport(enableDigest);
-                elementWatcher.exitViewport(disableDigest);
-                scope.$on("toggleWatchers", function(event, enable) {
-                    toggleWatchers(scope, enable);
-                });
-                scope.$on("$destroy", function() {
-                    elementWatcher.destroy();
+            }
+            function disableDigest() {
+                toggleWatchers(scope, false);
+            }
+            function enableDigest() {
+                toggleWatchers(scope, true);
+            }
+            function disableDigestingIfOutsideViewport() {
+                if (!elementWatcher.isInViewport) {
+                    disableDigest();
                     debouncedViewportUpdate();
-                });
-            };
+                }
+            }
+            scope.$applyAsync(disableDigestingIfOutsideViewport);
+
+            elementWatcher.enterViewport(enableDigest);
+            elementWatcher.exitViewport(disableDigest);
+            scope.$on("toggleWatchers", function(event, enable) {
+                toggleWatchers(scope, enable);
+            });
+            scope.$on("$destroy", function() {
+                elementWatcher.destroy();
+                debouncedViewportUpdate();
+            });
+        };
 
         return {
             restrict: "AE",

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -1,7 +1,7 @@
 "use strict";
 
 (function() {
-    function viewportWatch(scrollMonitor, $timeout, $parse) {
+    function viewportWatch(scrollMonitor, $timeout, $parse, $rootScope) {
         var viewportUpdateTimeout;
         function debouncedViewportUpdate() {
             $timeout.cancel(viewportUpdateTimeout);
@@ -97,6 +97,6 @@
             link: link
         };
     }
-    viewportWatch.$inject = [ "scrollMonitor", "$timeout", "$parse" ];
+    viewportWatch.$inject = [ "scrollMonitor", "$timeout", "$parse", "$rootScope" ];
     angular.module("angularViewportWatch", []).directive("viewportWatch", viewportWatch).value("scrollMonitor", window.scrollMonitor);
 })();

--- a/angular-viewport-watch.js
+++ b/angular-viewport-watch.js
@@ -10,6 +10,17 @@
             }, 10);
         }
 
+        function createDebouncing(theThis, func, delay) {
+            var debounceTimeout;
+            var debounced = function () {
+                clearTimeout(debounceTimeout);
+                debounceTimeout = setTimeout(function () {
+                    func.call(theThis);
+                }, delay);
+            };
+            return debounced;
+        }
+
         var link = function(scope, element, attr) {
             if($parse(attr.viewportWatch)(scope) == false){
                 return false;
@@ -65,6 +76,13 @@
                 } while (next);
                 if (digest) {
                     scope.$digest();
+
+                    if (!$rootScope.debouncingApplyAsync) {
+                        $rootScope.debouncingApplyAsync = createDebouncing($rootScope, function () {
+                            $rootScope.$applyAsync();
+                        }, 10);
+                    }
+                    $rootScope.debouncingApplyAsync();
                 }
             }
             function disableDigest() {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-viewport-watch",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "angular-viewport-watch.js",
   "ignore": [
     ".*",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "^1.2.0",
-    "scrollMonitor": "https://github.com/dirkgroenen/scrollMonitor.git#1.0.15"
+    "scrollMonitor": "https://github.com/cookbrite/scrollMonitor.git#1.0.16"
   },
   "devDependencies": {
     "angular-mocks": "^1.2.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-viewport-watch",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "angular-viewport-watch.js",
   "ignore": [
     ".*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-viewport-watch",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "angular-viewport-watch.js",
   "ignore": [
     ".*",


### PR DESCRIPTION
Perform a debouncing root digest when watchers are enabled.
- Added `createDebouncingVersion()` to create a debouncing version of `scope.$applyAsync()`

Small tweaks:
- Renamed a local variable
- Some code indentation was changed.
